### PR TITLE
Renamed CodeVert to Falcon

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,4 +1,4 @@
-# CodeVert
+# Falcon
 
 ## Functionalities (Personal)
 


### PR DESCRIPTION
The name of the bot and repository have been changed, then why leave out the README? What crime has it committed to deserve such a punishment?